### PR TITLE
Remove ts-essentials dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,5 @@
     "rollup": "^1.6.0",
     "rollup-plugin-babel": "^4.3.2",
     "typescript": "^4.5.4"
-  },
-  "dependencies": {
-    "ts-essentials": "^9.1.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { Writable } from 'ts-essentials'
 
 // basically Exclude<React.ClassAttributes<T>["ref"], string>
 type UserRef<T> =
@@ -7,6 +6,8 @@ type UserRef<T> =
   | React.RefObject<T>
   | null
   | undefined
+
+type Writable<T> = { -readonly [P in keyof T]: T[P] }
 
 const updateRef = <T>(ref: NonNullable<UserRef<T>>, value: T | null) => {
   if (typeof ref === 'function') {


### PR DESCRIPTION
`ts-essentials` has a peer dependency on `typescript` which means that this package would then have to also have a peer dependency on `typescript` to avoid an [implicit transitive peer dependency](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0). Without that peer dependency it produces a warning in Yarn 2:

➤ YN0002: │ use-composed-ref@npm:1.2.0 [044bc] doesn't provide typescript (p6ab00), requested by ts-essentials

 This PR removes the dependency on ts-essentials by inlining the single type we were using from that package so that we can avoid the problem altogether. See https://github.com/Andarist/use-composed-ref/pull/3 for more context.