### PR TITLE
Support React 18 as a peer-dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 
 node_js:
-  - "node"
+  - "lts/*"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/Andarist/use-composed-ref#readme",
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.3.4",


### PR DESCRIPTION
Adds support for the recently released [React 18](https://reactjs.org/blog/2022/03/29/react-v18.html).